### PR TITLE
Wrap long lines in changelog entries: 0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tex-common (6.15) UNRELEASED; urgency=medium
+
+  * Wrap long lines in changelog entries: 0.5.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 06:08:39 +0000
+
 tex-common (6.14) unstable; urgency=medium
 
   * Add luajithbtex to the list of TeX engines where missing formats
@@ -1537,7 +1543,8 @@ tex-common (0.5) unstable; urgency=low
 
   * Merge update-fmtutil into update-fontlang  (closes: #319651)
   * Fix installation of manpages
-  * add bibtex/csf to texmf variable BSTINPUTS in 65BibTeX.cnf  (closes: #319650)
+  * add bibtex/csf to texmf variable BSTINPUTS in 65BibTeX.cnf  (closes:
+    #319650)
   * Many thanks to Norbert Preining <preining@logic.at> for providing
     patches for these changes.
   * Increase trie_size in 95NonPath.cnf to 27000, to allow TeX-Live build


### PR DESCRIPTION
Wrap long lines in changelog entries: 0.5. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/tex-common/b41892fd-f65b-4c7c-a5d2-565b9dbef9bb.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/b41892fd-f65b-4c7c-a5d2-565b9dbef9bb/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/b41892fd-f65b-4c7c-a5d2-565b9dbef9bb/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/b41892fd-f65b-4c7c-a5d2-565b9dbef9bb/diffoscope)).
