### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+tex-common (6.17) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + tex-common: Drop versioned constraint on debhelper in Suggests.
+    + tex-common: Drop versioned constraint on dpkg in Pre-Depends.
+    + tex-common: Drop versioned constraint on context in Conflicts.
+    + tex-common: Drop versioned constraint on alqalam, cm-super,
+      latex-cjk-japanese-wadalab, lmodern, tex-gyre, texlive-base and tipa in
+      Breaks.
+    + Remove 3 maintscript entries from 1 files.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Aug 2021 03:58:33 -0000
+
 tex-common (6.16) unstable; urgency=medium
 
   [ Helmut Grohne <helmut@subdivi.de> ]

--- a/debian/control
+++ b/debian/control
@@ -17,11 +17,11 @@ Package: tex-common
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ucf
-Pre-Depends: dpkg (>= 1.16.1)
-Suggests: debhelper (>= 9)
+Pre-Depends: dpkg
+Suggests: debhelper
 Replaces: tetex-base (<= 3.0-10), dvipdfmx
-Conflicts: tetex-base (<< 2007), texlive-common (<< 2009), context (<= 2011.05.18.20110627-1)
-Breaks: texlive-common (<< 2010), tipa (<= 2:1.3-15), itrans (<= 5.3-10), gregoriotex (<= 2.0-1.1), cm-super (<< 0.3.4-12), cm-super-minimal (<< 0.3.4-12), latex-cjk-chinese-arphic-bkai00mp (<= 1.21+nmu1), latex-cjk-japanese-wadalab (<= 0.20050817-15), latex-fonts-sipa-arundina (<= 0.2.0-1), latex-fonts-thai-tlwg (<= 1:0.5.0-1), lmodern (<= 2.004.1-3.1), ko.tex-base (<= 0.1.0+20071012-1), ko.tex-extra (<= 0.1.0+20071012-1), latex-cjk-chinese-arphic-bsmi00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gbsn00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gkai00mp (<= 1.21+nmu1), latex-cjk-thai (<= 4.8.2+git20111216-1), latex-cjk-chinese (<< 4.8.2+git20111216-2), latex-sanskrit (<= 2.2-8), musixtex (<= 1:0.115-2), scalable-cyrfonts-tex (<= 4.15), tex-gyre (<= 2.004.1-2.1), jadetex (<= 3.13-12), luatex (<< 0.70.1), texlive-lang-arab (<< 2012), context-doc-nonfree (<= 2012.06.27-1), alqalam (<= 0.2-5), thailatex (<< 2013), texlive-binaries (<< 2015), texlive-base (<< 2015)
+Conflicts: tetex-base (<< 2007), texlive-common (<< 2009)
+Breaks: texlive-common (<< 2010), itrans (<= 5.3-10), gregoriotex (<= 2.0-1.1), cm-super-minimal (<< 0.3.4-12), latex-cjk-chinese-arphic-bkai00mp (<= 1.21+nmu1), latex-fonts-sipa-arundina (<= 0.2.0-1), latex-fonts-thai-tlwg (<= 1:0.5.0-1), ko.tex-base (<= 0.1.0+20071012-1), ko.tex-extra (<= 0.1.0+20071012-1), latex-cjk-chinese-arphic-bsmi00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gbsn00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gkai00mp (<= 1.21+nmu1), latex-cjk-thai (<= 4.8.2+git20111216-1), latex-cjk-chinese (<< 4.8.2+git20111216-2), latex-sanskrit (<= 2.2-8), musixtex (<= 1:0.115-2), scalable-cyrfonts-tex (<= 4.15), jadetex (<= 3.13-12), luatex (<< 0.70.1), texlive-lang-arab (<< 2012), context-doc-nonfree (<= 2012.06.27-1), thailatex (<< 2013), texlive-binaries (<< 2015)
 Provides: dh-sequence-tex
 Description: common infrastructure for building and installing TeX
  This package contains a number of scripts and common configuration

--- a/debian/maintscript
+++ b/debian/maintscript
@@ -1,3 +1,0 @@
-rm_conffile /etc/texmf/language.d/00tex.cnf 2.11
-rm_conffile /etc/texmf/fmt.d/00tex.cnf 6.00~
-rm_conffile /etc/texmf/hyphen.d/00tex.cnf 6.00~


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/tex-common/5f5165d8-61ad-4612-8fca-9557e1c3b14f.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Breaks: [-alqalam (<= 0.2-5), cm-super (<< 0.3.4-12),-] cm-super-minimal (<< 0.3.4-12), context-doc-nonfree (<= 2012.06.27-1), gregoriotex (<= 2.0-1.1), itrans (<= 5.3-10), jadetex (<= 3.13-12), ko.tex-base (<= 0.1.0+20071012-1), ko.tex-extra (<= 0.1.0+20071012-1), latex-cjk-chinese (<< 4.8.2+git20111216-2), latex-cjk-chinese-arphic-bkai00mp (<= 1.21+nmu1), latex-cjk-chinese-arphic-bsmi00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gbsn00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gkai00mp (<= 1.21+nmu1), [-latex-cjk-japanese-wadalab (<= 0.20050817-15),-] latex-cjk-thai (<= 4.8.2+git20111216-1), latex-fonts-sipa-arundina (<= 0.2.0-1), latex-fonts-thai-tlwg (<= 1:0.5.0-1), latex-sanskrit (<= 2.2-8), [-lmodern (<= 2.004.1-3.1),-] luatex (<< 0.70.1), musixtex (<= 1:0.115-2), scalable-cyrfonts-tex (<= 4.15), [-tex-gyre (<= 2.004.1-2.1), texlive-base (<< 2015),-] texlive-binaries (<< 2015), texlive-common (<< 2010), texlive-lang-arab (<< 2012), thailatex (<< [-2013), tipa (<= 2:1.3-15)-] {+2013)+}
* Conflicts: [-context (<= 2011.05.18.20110627-1),-] tetex-base (<< 2007), texlive-common (<< 2009)
* Pre-Depends: dpkg [-(>= 1.16.1)-]
* Suggests: debhelper [-(>= 9)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5f5165d8-61ad-4612-8fca-9557e1c3b14f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5f5165d8-61ad-4612-8fca-9557e1c3b14f/diffoscope)).
