### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ tex-common (6.17) UNRELEASED; urgency=medium
       Breaks.
     + Remove 3 maintscript entries from 1 files.
   * Use set -e rather than passing -e on the shebang-line.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Aug 2021 03:58:33 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ tex-common (6.17) UNRELEASED; urgency=medium
       latex-cjk-japanese-wadalab, lmodern, tex-gyre, texlive-base and tipa in
       Breaks.
     + Remove 3 maintscript entries from 1 files.
+  * Use set -e rather than passing -e on the shebang-line.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Aug 2021 03:58:33 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Uploaders: Julian Gilbey <jdg@debian.org>,
 Build-Depends: debhelper-compat (= 13)
 Build-Depends-Indep: help2man
 Rules-Requires-Root: no
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Vcs-Git: https://github.com/debian-tex/tex-common.git
 Vcs-Browser: https://github.com/debian-tex/tex-common
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 # 
 # postrm maintainer script for the Debian tex-common package.
 #
@@ -21,6 +21,8 @@
 #
 # On Debian GNU/Linux System you can find a copy of the GNU General Public
 # License in "/usr/share/common-licenses/GPL".
+
+set -e
 
 # give commandline args a name
 action=$1 # remove, purge, upgrade, failed-upgrade, abort-install, abort-upgrade, disappear

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 # 
 # preinst maintainer script for the Debian tex-common package.
 #
@@ -20,6 +20,8 @@
 #
 # On Debian GNU/Linux System you can find a copy of the GNU General Public
 # License in "/usr/share/common-licenses/GPL".
+
+set -e
 
 umask 022
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Use set -e rather than passing -e on the shebang-line. ([maintainer-script-without-set-e](https://lintian.debian.org/tags/maintainer-script-without-set-e))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/tex-common/d9d3fe62-c7fb-4605-8858-ea038d49fd1e.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/d9d3fe62-c7fb-4605-8858-ea038d49fd1e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d9d3fe62-c7fb-4605-8858-ea038d49fd1e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d9d3fe62-c7fb-4605-8858-ea038d49fd1e/diffoscope)).
