### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+tex-common (6.19) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + tex-common: Drop versioned constraint on cm-super-minimal, ko.tex-base,
+      ko.tex-extra, latex-cjk-chinese, latex-cjk-chinese-arphic-bkai00mp,
+      latex-cjk-chinese-arphic-bsmi00lp, latex-cjk-chinese-arphic-gbsn00lp,
+      latex-cjk-chinese-arphic-gkai00mp, latex-cjk-thai,
+      latex-fonts-sipa-arundina, scalable-cyrfonts-tex and texlive-binaries in
+      Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 17 Nov 2022 19:51:44 -0000
+
 tex-common (6.18) unstable; urgency=medium
 
   [ Hilmar Preusse ]

--- a/debian/control
+++ b/debian/control
@@ -20,21 +20,11 @@ Depends: ${misc:Depends}, ucf
 Suggests: debhelper
 Replaces: tetex-base (<= 3.0-10), dvipdfmx
 Breaks: tetex-base (<< 2007), texlive-common (<< 2010), itrans (<= 5.3-10),
-        gregoriotex (<= 2.0-1.1), cm-super-minimal (<< 0.3.4-12),
-        latex-cjk-chinese-arphic-bkai00mp (<= 1.21+nmu1),
-        latex-fonts-sipa-arundina (<= 0.2.0-1),
-        latex-fonts-thai-tlwg (<= 1:0.5.0-1), ko.tex-base (<= 0.1.0+20071012-1),
-        ko.tex-extra (<= 0.1.0+20071012-1),
-        latex-cjk-chinese-arphic-bsmi00lp (<= 1.21+nmu1),
-        latex-cjk-chinese-arphic-gbsn00lp (<= 1.21+nmu1),
-        latex-cjk-chinese-arphic-gkai00mp (<= 1.21+nmu1),
-        latex-cjk-thai (<= 4.8.2+git20111216-1),
-        latex-cjk-chinese (<< 4.8.2+git20111216-2),
-        latex-sanskrit (<= 2.2-8), musixtex (<= 1:0.115-2),
-        scalable-cyrfonts-tex (<= 4.15), jadetex (<= 3.13-12),
+        gregoriotex (<= 2.0-1.1),
+        latex-fonts-thai-tlwg (<= 1:0.5.0-1),
+        latex-sanskrit (<= 2.2-8), musixtex (<= 1:0.115-2), jadetex (<= 3.13-12),
         luatex (<< 0.70.1), texlive-lang-arab (<< 2012),
-        context-doc-nonfree (<= 2012.06.27-1), thailatex (<< 2013),
-        texlive-binaries (<< 2015)
+        context-doc-nonfree (<= 2012.06.27-1), thailatex (<< 2013)
 Provides: dh-sequence-tex
 Description: common infrastructure for building and installing TeX
  This package contains a number of scripts and common configuration


### PR DESCRIPTION
Remove unnecessary constraints.
## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Breaks: [-cm-super-minimal (<< 0.3.4-12),-] context-doc-nonfree (<= 2012.06.27-1), gregoriotex (<= 2.0-1.1), itrans (<= 5.3-10), jadetex (<= 3.13-12), [-ko.tex-base (<= 0.1.0+20071012-1), ko.tex-extra (<= 0.1.0+20071012-1), latex-cjk-chinese (<< 4.8.2+git20111216-2), latex-cjk-chinese-arphic-bkai00mp (<= 1.21+nmu1), latex-cjk-chinese-arphic-bsmi00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gbsn00lp (<= 1.21+nmu1), latex-cjk-chinese-arphic-gkai00mp (<= 1.21+nmu1), latex-cjk-thai (<= 4.8.2+git20111216-1), latex-fonts-sipa-arundina (<= 0.2.0-1),-] latex-fonts-thai-tlwg (<= 1:0.5.0-1), latex-sanskrit (<= 2.2-8), luatex (<< 0.70.1), musixtex (<= 1:0.115-2), [-scalable-cyrfonts-tex (<= 4.15),-] tetex-base (<< 2007), [-texlive-binaries (<< 2015),-] texlive-common (<< 2010), texlive-lang-arab (<< 2012), thailatex (<< 2013)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/cb7b7d3f-e521-4d75-ba56-c729059c11a2/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/cb7b7d3f-e521-4d75-ba56-c729059c11a2/diffoscope)).


This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/tex-common/cb7b7d3f-e521-4d75-ba56-c729059c11a2.